### PR TITLE
Lock file bypassed in docker

### DIFF
--- a/soularr.py
+++ b/soularr.py
@@ -385,7 +385,7 @@ def is_docker():
     return os.getenv('IN_DOCKER') is not None
 
 if is_docker():
-    lock_file_path = os.path.join(os.getcwd(), "/data/.soularr.lock")
+    lock_file_path = ""
     config_file_path = os.path.join(os.getcwd(), "/data/config.ini")
     failure_file_path = os.path.join(os.getcwd(), "/data/failure_list.txt")
 else:
@@ -393,13 +393,14 @@ else:
     config_file_path = os.path.join(os.getcwd(), "config.ini")
     failure_file_path = os.path.join(os.getcwd(), "failure_list.txt")
     
-if os.path.exists(lock_file_path):
+if os.path.exists(lock_file_path) and not is_docker():
     print(f"Soularr instance is already running.")
     sys.exit(1)
 
 try:
-    with open(lock_file_path, "w") as lock_file:
-        lock_file.write("locked")
+    if not is_docker():
+        with open(lock_file_path, "w") as lock_file:
+            lock_file.write("locked")
 
     config = configparser.ConfigParser()
 
@@ -468,7 +469,7 @@ try:
             print(traceback.format_exc())
             print("\n Fatal error! Exiting...")
 
-            if os.path.exists(lock_file_path):
+            if os.path.exists(lock_file_path) and not is_docker():
                 os.remove(lock_file_path)
             sys.exit(0)
         if failed == 0:
@@ -485,5 +486,5 @@ try:
 
 finally:
     # Remove the lock file after activity is done
-    if os.path.exists(lock_file_path):
+    if os.path.exists(lock_file_path) and not is_docker():
         os.remove(lock_file_path)


### PR DESCRIPTION
is_docker checks applied to all usages of the lock file in order to ignore it when using docker. Also, setting the lock_file_path as an empty string can accomplish the same thing by always returning false.

This has not been tested as I am currently running a very long running process for work but I wanted to throw something together really quick to try and solve issue #16 