### PR TITLE
Added logic to delete the search from SLSKD

### DIFF
--- a/soularr.py
+++ b/soularr.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import math
 import re
 import os
@@ -199,6 +201,8 @@ def search_and_download(grab_list, querry, tracks, track, artist_name, release):
 
                         try:
                             slskd.transfers.enqueue(username = username, files = directory['files'])
+                            # Delete the search from SLSKD DB
+                            slskd.searches.delete(search['id'])
                             return True
                         except Exception:
                             ignored_users.append(username)
@@ -206,6 +210,9 @@ def search_and_download(grab_list, querry, tracks, track, artist_name, release):
                             print("Error enqueueing tracks! Adding " + username + " to ignored users list.")
                             #print(traceback.format_exc())
                             continue
+
+    # Delete the search from SLSKD DB
+    slskd.searches.delete(search['id'])
     return False
 
 def is_blacklisted(title: str) -> bool:


### PR DESCRIPTION
I've noticed that the search DB in slskd grows to be quite large

-rw-r--r-- 1 dave dave **50528256** Oct 11 09:34 search.db

This update deletes the search after it's been processed.