### PR TITLE
Added logic to allow user to select config file and config dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
 /.venv
+.venv
+.vscode
+config.ini.*
+run.sh
+.current_page.txt
+.pylintrc
+.gitignore
+.soularr.lock

--- a/soularr.py
+++ b/soularr.py
@@ -403,7 +403,7 @@ def grab_most_wanted(albums):
         download_dir = os.path.join(lidarr_download_dir,artist_folder)
         command = lidarr.post_command(name = 'DownloadedAlbumsScan', path = download_dir)
         commands.append(command)
-        print("Starting Lidarr import for: " + artist_folder + " ID: " + str(command['id']))
+        print(f"Starting Lidarr import for: {artist_folder} - {album_title} - ID: {str(command['id'])}")
 
     while True:
         completed_count = 0

--- a/soularr.py
+++ b/soularr.py
@@ -202,9 +202,10 @@ def search_and_download(grab_list, querry, tracks, track, artist_name, release):
                             return True
                         except Exception:
                             ignored_users.append(username)
-                            grab_list.remove(folder_data)
+
                             print("Error enqueueing tracks! Adding " + username + " to ignored users list.")
-                            #print(traceback.format_exc())
+                            grab_list.remove(folder_data)
+                            cancel_and_delete(file_dir.split("\\")[-1], username, directory["files"])
                             continue
     return False
 

--- a/soularr.py
+++ b/soularr.py
@@ -336,11 +336,13 @@ def grab_most_wanted(albums):
 
     os.chdir(slskd_download_dir)
     commands = []
+    artist_folders = []
     grab_list.sort(key=operator.itemgetter('artist_name'))
 
     for artist_folder in grab_list:
         artist_name = artist_folder['artist_name']
         artist_name_sanitized = sanitize_folder_name(artist_name)
+        artist_folders.append(artist_name_sanitized)
         folder = artist_folder['dir']
 
         if artist_folder['release']['mediumCount'] > 1:
@@ -370,9 +372,6 @@ def grab_most_wanted(albums):
 
         elif os.path.exists(folder):
             shutil.move(folder,artist_name_sanitized)
-
-    artist_folders = next(os.walk('.'))[1]
-    artist_folders = [folder for folder in artist_folders if folder != 'failed_imports']
 
     for artist_folder in artist_folders:
         download_dir = os.path.join(lidarr_download_dir,artist_folder)
@@ -416,8 +415,9 @@ def move_failed_import(src_path):
         target_path = os.path.join(failed_imports_dir, f"{folder_name}_{counter}")
         counter += 1
     
-    shutil.move(folder_name, target_path)
-    print("Failed import moved to: " + target_path)
+    if os.path.exists(folder_name):
+        shutil.move(folder_name, target_path)
+        print("Failed import moved to: " + target_path)
 
 def is_docker():
     return os.getenv('IN_DOCKER') is not None

--- a/soularr.py
+++ b/soularr.py
@@ -201,11 +201,14 @@ def search_and_download(grab_list, querry, tracks, track, artist_name, release):
                             slskd.transfers.enqueue(username = username, files = directory['files'])
                             return True
                         except Exception:
-                            ignored_users.append(username)
-
                             print("Error enqueueing tracks! Adding " + username + " to ignored users list.")
-                            grab_list.remove(folder_data)
-                            cancel_and_delete(file_dir.split("\\")[-1], username, directory["files"])
+                            downloads = slskd.transfers.get_downloads(username)
+
+                            for cancel_directory in downloads["directories"]:
+                                if cancel_directory["directory"] == directory["name"]:
+                                    cancel_and_delete(file_dir.split("\\")[-1], username, cancel_directory["files"])
+                                    grab_list.remove(folder_data)
+                                    ignored_users.append(username)
                             continue
     return False
 

--- a/soularr.py
+++ b/soularr.py
@@ -10,6 +10,7 @@ import difflib
 import operator
 import traceback
 import configparser
+import argparse
 from datetime import datetime
 
 import music_tag
@@ -448,17 +449,33 @@ def move_failed_import(src_path):
 def is_docker():
     return os.getenv('IN_DOCKER') is not None
 
+def create_argument_parser():
+    ''' Process the command line arguments '''
+
+    parser = argparse.ArgumentParser(description="Soularr")
+
+    cwd = os.getcwd()
+    parser.add_argument("--config_file", help="Path to config file", default="config.ini")
+    parser.add_argument("--config_dir", help="Path to config directory", default=cwd)
+
+    args = parser.parse_args()
+
+    return args
+
+# The follwoing should really be in main()
+arguments = create_argument_parser()
+
 if is_docker():
     lock_file_path = ""
     config_file_path = os.path.join(os.getcwd(), "/data/config.ini")
     failure_file_path = os.path.join(os.getcwd(), "/data/failure_list.txt")
     current_page_file_path = os.path.join(os.getcwd(), "/data/.current_page.txt")
 else:
-    lock_file_path = os.path.join(os.getcwd(), ".soularr.lock")
-    config_file_path = os.path.join(os.getcwd(), "config.ini")
-    failure_file_path = os.path.join(os.getcwd(), "failure_list.txt")
-    current_page_file_path = os.path.join(os.getcwd(), ".current_page.txt")
-    
+    lock_file_path = os.path.join(arguments.config_dir, ".soularr.lock")
+    config_file_path = os.path.join(arguments.config_dir, arguments.config_file)
+    failure_file_path = os.path.join(arguments.config_dir, "failure_list.txt")
+    current_page_file_path = os.path.join(arguments.config_dir, ".current_page.txt")
+
 if os.path.exists(lock_file_path) and not is_docker():
     print(f"Soularr instance is already running.")
     sys.exit(1)
@@ -483,7 +500,6 @@ try:
         if os.path.exists(lock_file_path) and not is_docker():
             os.remove(lock_file_path)
         sys.exit(0)
- 
     slskd_api_key = config['Slskd']['api_key']
     lidarr_api_key = config['Lidarr']['api_key']
 

--- a/soularr.py
+++ b/soularr.py
@@ -345,7 +345,10 @@ def grab_most_wanted(albums):
     for artist_folder in grab_list:
         artist_name = artist_folder['artist_name']
         artist_name_sanitized = sanitize_folder_name(artist_name)
-        artist_folders.append(artist_name_sanitized)
+
+        if artist_name_sanitized not in artist_folders:
+            artist_folders.append(artist_name_sanitized)
+
         folder = artist_folder['dir']
 
         if artist_folder['release']['mediumCount'] > 1:

--- a/soularr.py
+++ b/soularr.py
@@ -367,7 +367,7 @@ def grab_most_wanted(albums):
                 if not os.path.exists(new_dir):    
                     os.mkdir(new_dir)
 
-                if os.path.exists(os.path.join(folder,filename)):
+                if os.path.exists(os.path.join(folder,filename)) and not os.path.exists(os.path.join(new_dir,filename)):
                     shutil.move(os.path.join(folder,filename),new_dir)
 
             if os.path.exists(folder):        

--- a/soularr.py
+++ b/soularr.py
@@ -339,15 +339,11 @@ def grab_most_wanted(albums):
 
     os.chdir(slskd_download_dir)
     commands = []
-    artist_folders = []
     grab_list.sort(key=operator.itemgetter('artist_name'))
 
     for artist_folder in grab_list:
         artist_name = artist_folder['artist_name']
         artist_name_sanitized = sanitize_folder_name(artist_name)
-
-        if artist_name_sanitized not in artist_folders:
-            artist_folders.append(artist_name_sanitized)
 
         folder = artist_folder['dir']
 
@@ -378,6 +374,9 @@ def grab_most_wanted(albums):
 
         elif os.path.exists(folder):
             shutil.move(folder,artist_name_sanitized)
+
+    artist_folders = next(os.walk('.'))[1]
+    artist_folders = [folder for folder in artist_folders if folder != 'failed_imports']
 
     for artist_folder in artist_folders:
         download_dir = os.path.join(lidarr_download_dir,artist_folder)

--- a/soularr.py
+++ b/soularr.py
@@ -408,7 +408,7 @@ def grab_most_wanted(albums):
         completed_count = 0
         for task in commands:
             current_task = lidarr.get_command(task['id'])
-            if current_task['status'] == 'completed':
+            if current_task['status'] == 'completed' or current_task['status'] == 'failed':
                 completed_count += 1
         if completed_count == len(commands):
             break


### PR DESCRIPTION
While testing a change, I wanted to experiment with different config data. It seemed (at least to me) to make sense to allow the user to select an alternative config file. I also added an option to allow the user to select a directory to contain all the dynamic files like page and failed.

```
usage: soularr.py [-h] [--config_file CONFIG_FILE] [--config_dir CONFIG_DIR]

Soularr

options:
  -h, --help            show this help message and exit
  --config_file CONFIG_FILE
                        Path to config file
  --config_dir CONFIG_DIR
                        Path to config directory
```

The other minor update was to add the Album Title to the importing message.