### PR TITLE
Add option to disable lidarr sync on download

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -2,6 +2,7 @@
 api_key = yourlidarrapikeygoeshere
 host_url = http://localhost:8686
 download_dir = /lidarr/path/to/slskd/downloads
+disable_sync = False
 
 [Slskd]
 api_key = yourslskdapikeygoeshere

--- a/soularr.py
+++ b/soularr.py
@@ -499,6 +499,9 @@ def grab_most_wanted(albums):
         elif os.path.exists(folder):
             shutil.move(folder,artist_name_sanitized)
 
+    if lidarr_disable_sync:
+        return failed_download
+
     artist_folders = next(os.walk('.'))[1]
     artist_folders = [folder for folder in artist_folders if folder != 'failed_imports']
 
@@ -682,6 +685,7 @@ try:
     lidarr_api_key = config['Lidarr']['api_key']
 
     lidarr_download_dir = config['Lidarr']['download_dir']
+    lidarr_disable_sync = config.getboolean('Lidarr', 'disable_sync', fallback=False)
 
     slskd_download_dir = config['Slskd']['download_dir']
 


### PR DESCRIPTION
Hi, this adds an option named `disable_sync` in the Lidarr section that defaults to `False`. 
If set to `True` it will stop soularr from automatically sending a request to lidarr to scan for new downloads.

One thing I'm not sure about is if the early return from the `grab_most_wanted` should be placed even further up on line 461, effectively stopping soularr from moving files around. Please advice on this.