### PR TITLE
Added rudamentry single file retry

### DIFF
--- a/soularr.py
+++ b/soularr.py
@@ -451,8 +451,8 @@ def grab_most_wanted(albums):
                         grab_list.remove(artist_folder)
                         for file in directory['files']:
                             del retry_list[username][file['filename']]
-                            if len(retry_list[username]) > 0:
-                                del retry_list[username]
+                        if len(retry_list[username]) <= 0:
+                             del retry_list[username]
                     elif len(pending_files) > 0:
                         unfinished += 1
 


### PR DESCRIPTION
Added rudimentary single file retry. Retries failed files 2 times as I encountered users who had all the files but ran into weird connection issues meaning I would get 90% of the tracks on an album and have a single file fail, only to have that file work correctly if manually retired. 

Reversed the retry mechanism from the slskd web-ui and implemented a basic 2 retry per file mechanism. Should be trivial to add configuration options to increase or decrease the number (to 0 to match current behavior) 

Also added a cleanup to get rid of a warning. 