### PR TITLE
Added file filter including whitelist functionality.

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -34,6 +34,11 @@ remove_wanted_on_failure = False
 title_blacklist = BlacklistWord1,blacklistword2
 search_source = missing
 
+[Download Settings]
+download_filtering = True
+use_extension_whitelist = False
+extensions_whitelist = lrc,nfo,txt
+
 [Logging]
 level = INFO
 # https://docs.python.org/3/library/logging.html#logrecord-attributes


### PR DESCRIPTION
When enabled this will filter the downloaded files to exclude everything except the files of the matched format. 

If you also enable the whitelist feature, you can have it also grab files of the whitelisted extensions. 

For example if you wanted to get lyrics as well you could add lrc to the whitelist and it would get the matched files and the lrc files. 

Or you could add jpg to get covers and such. 