### PR TITLE
Track script executable bit with git, run through tr to remove \r, fix signal handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-RUN sed -i 's/\r$//' run.sh
-
-RUN chmod +x run.sh
-
 ENV PYTHONUNBUFFERED=1
 ENV IN_DOCKER=Yes
 

--- a/run.sh
+++ b/run.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
+trap '[[ $pid ]] && kill "$pid"' EXIT
+
 #This script is used when running the app through docker. It handles scheduling the script.
 
 #Default interval is 300 seconds (5 minutes) if not set
 
 INTERVAL=${SCRIPT_INTERVAL:-300}
 
+pid=
 while true; do
     if ps aux | grep "[s]oularr.py" > /dev/null; then
         echo "Soularr is already running. Exiting..."
@@ -16,5 +19,6 @@ while true; do
 
     dt=$(date '+%d/%m/%Y %H:%M:%S');
     echo "$dt - Waiting for $INTERVAL seconds before checking again..."
-    sleep $INTERVAL
+    sleep $INTERVAL & pid=$!
+    wait $pid
 done


### PR DESCRIPTION
Really I wanted to fix the handling of signals here, the other changes are just sugar on top. Without the signal handling fix it is not possible to stop the container gracefully when you're stuck on sleeping. This always causes a delay (assuming folks are not always using `docker kill` which == SIGKILL) which makes this even more unfriendly for anyone running in the context of k8s.