### PR TITLE
Use tini as entrypoint in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,17 @@ FROM python:3.11
 
 WORKDIR /app
 
-COPY requirements.txt .
+COPY requirements.txt soularr.py run.sh .
 
-RUN pip install --no-cache-dir -r requirements.txt
-
-COPY . .
-
-RUN sed -i 's/\r$//' run.sh
-
-RUN chmod +x run.sh
+RUN apt-get update \
+    && apt-get install -y tini \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir -r requirements.txt \
+    && sed -i 's/\r$//' run.sh \
+    && chmod +x run.sh
 
 ENV PYTHONUNBUFFERED=1
 ENV IN_DOCKER=Yes
 
-ENTRYPOINT ["bash", "run.sh"]
+ENTRYPOINT ["tini", "-g", "--"]
+CMD ["/app/run.sh"]


### PR DESCRIPTION
You might have noticed that when the container has to be stopped (e.g. due to a restart), docker hangs for 10s before the container is finally killed. This is a common issue with containers that use long-running shell scripts as entrypoint - the shell always runs as PID 1 inside the container, and shells treat PID 1 specially and ignore TERM process signals. To avoid this, one should use a signal handler/forwarder as entrypoint, for example [tini](https://github.com/krallin/tini).

It's a minor QOL improvement, but if you'd like to fix this, here's my suggestion for the Dockerfile.