### PR TITLE
Add entry to skip region check completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ use_most_common_tracknum = True
 allow_multi_disc = True
 # Accepted release countries
 accepted_countries = Europe,Japan,United Kingdom,United States,[Worldwide],Australia,Canada
+# Don't check the region of the release
+skip_region_check = False 
 # Accepted formats
 accepted_formats = CD,Digital Media,Vinyl
 

--- a/config.ini
+++ b/config.ini
@@ -16,6 +16,7 @@ stalled_timeout = 3600
 use_most_common_tracknum = True
 allow_multi_disc = True
 accepted_countries = Europe,Japan,United Kingdom,United States,[Worldwide],Australia,Canada
+skip_region_check = False
 accepted_formats = CD,Digital Media,Vinyl
 
 [Search Settings]

--- a/soularr.py
+++ b/soularr.py
@@ -167,7 +167,7 @@ def choose_release(album_id, artist_name):
         else:
             track_count_bool = True
 
-        if (country in accepted_countries
+        if ((skip_region_check or country in accepted_countries)
             and format_accepted
             and release['status'] == "Official"
             and track_count_bool):
@@ -731,6 +731,7 @@ try:
     default_accepted_countries = "Europe,Japan,United Kingdom,United States,[Worldwide],Australia,Canada"
     default_accepted_formats = "CD,Digital Media,Vinyl"
     accepted_countries = config.get('Release Settings', 'accepted_countries', fallback=default_accepted_countries).split(",")
+    skip_region_check = config.getboolean('Release Settings', 'skip_region_check', fallback=False)
     accepted_formats = config.get('Release Settings', 'accepted_formats', fallback=default_accepted_formats).split(",")
 
     raw_filetypes = config.get('Search Settings', 'allowed_filetypes', fallback='flac,mp3')


### PR DESCRIPTION
This PR introduced a variable in the config file to skip the region check completely. It addresses issue #113 

To skip the check all the user has to do is set `skip_region_check = True`.

