### PR TITLE
Clarify search_for_tracks setting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ minimum_filename_match_ratio = 0.8
 # Use "flac" or "mp3" to ignore quality details
 allowed_filetypes = flac 24/192,flac 16/44.1,flac,mp3 320,mp3
 ignored_users = User1,User2,Fred,Bob
-# Set to False to only search for album titles. Set to True to fallback to search for track titles, then match the directory that contains the track to album title.
+# Set to False to only search for album titles. Set to True to fallback to search for track titles, then match the directory that contains the track to the album title.
 search_for_tracks = True
 # Prepend artist name when searching for albums
 album_prepend_artist = False


### PR DESCRIPTION
The current text in the README related to search_for_tracks was not fully clear to me.

After questioning in the discord on what this actually does I feel this might reflect better its purpose.