### PR TITLE
feat: implemeant a search deny list

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,10 @@ remove_wanted_on_failure = False
 title_blacklist = Word1,word2
 # Lidarr search source: "missing" or "cutoff_unmet"
 search_source = missing
+# Enable search denylist to skip albums that repeatedly fail
+enable_search_denylist = False
+# Number of consecutive search failures before denylisting
+max_search_failures = 3
 
 [Logging]
 # Passed to Python's logging.basicConfig()

--- a/config.ini
+++ b/config.ini
@@ -34,6 +34,8 @@ number_of_albums_to_grab = 10
 remove_wanted_on_failure = False
 title_blacklist = BlacklistWord1,blacklistword2
 search_source = missing
+enable_search_denylist = False
+max_search_failures = 3
 
 [Logging]
 level = INFO

--- a/soularr.py
+++ b/soularr.py
@@ -822,7 +822,7 @@ try:
     minimum_match_ratio = config.getfloat('Search Settings', 'minimum_filename_match_ratio', fallback=0.5)
     page_size = config.getint('Search Settings', 'number_of_albums_to_grab', fallback=10)
     remove_wanted_on_failure = config.getboolean('Search Settings', 'remove_wanted_on_failure', fallback=True)
-    enable_search_denylist = config.getboolean('Search Settings', 'enable_search_denylist', fallback=True)
+    enable_search_denylist = config.getboolean('Search Settings', 'enable_search_denylist', fallback=False)
     max_search_failures = config.getint('Search Settings', 'max_search_failures', fallback=3)
 
     use_most_common_tracknum = config.getboolean('Release Settings', 'use_most_common_tracknum', fallback=True)

--- a/soularr.py
+++ b/soularr.py
@@ -709,8 +709,10 @@ def update_search_denylist(denylist, album_id, success):
 
     if success:
         if album_key in denylist:
+            logger.info("Removing album from denylist: " + denylist[album_key]['album_id'])
             del denylist[album_key]
     else:
+        logger.info("Adding album to denylist: " + album_key)
         if album_key in denylist:
             denylist[album_key]['failures'] += 1
             denylist[album_key]['last_attempt'] = current_datetime_str


### PR DESCRIPTION
soularr always tries to search whatever lidarr is monitoring (wants) and often I find it stuck in a cycle of repeatedly trying to find something that it will never find. 

the option `remove_wanted_on_failure` will instruct lidarr to not want the album anymore but this prevents other scripts of my own that will try to find albums when soularr could not get them on its own. 

The new option is called `enable_search_denylist` with an option for `max_search_failures`

it works like this (if enabled):

* soularr tries to find album id X: if it fails to find it in this cycle it adds it to the search_denylist 
* next cycle soularr tries to find album X: if the album is in the search_denylist with more than X attempts. it skips it.

if the option is set to false there's  no side effects and soularr works exactly as expected.

This option will not interfere with `remove_wanted_on_failure` in anyway.



here's an example of th file `search_denylist.json` it uses to store the attempts:


```json
{
  "2105": {
    "failures": 2,
    "last_attempt": "2025-09-18T10:27:45",
    "album_id": 2105
  },
  "2136": {
    "failures": 2,
    "last_attempt": "2025-09-18T10:27:55",
    "album_id": 2136
  }
}
```


log example:


```bash
soularr       | [INFO|soularr|L364] 2025-09-18T12:21:08+0000: Skipping denylisted album: Mon Laferte - Amor completo (ID: 2105)
soularr       | [INFO|soularr|L364] 2025-09-18T12:21:08+0000: Skipping denylisted album: Andrés Cepeda - BOGOTÁ (ID: 2140)
soularr       | [INFO|soularr|L364] 2025-09-18T12:21:08+0000: Skipping denylisted album: Celeste - Both Sides of the Moon (ID: 2077)
soularr       | [INFO|soularr|L364] 2025-09-18T12:21:08+0000: Skipping denylisted album: Celeste - Celeste (ID: 2078)
soularr       | [INFO|soularr|L364] 2025-09-18T12:21:08+0000: Skipping denylisted album: Andrés Cepeda - El carpintero (ID: 2132)
soularr       | [INFO|soularr|L364] 2025-09-18T12:21:08+0000: Skipping denylisted album: Andrés Cepeda - Mil ciudades (ID: 2134)
soularr       | [INFO|soularr|L364] 2025-09-18T12:21:08+0000: Skipping denylisted album: Mon Laferte - Mon laferte. Canciones para el dolor (ID: 2108)
soularr       | [INFO|soularr|L364] 2025-09-18T12:21:08+0000: Skipping denylisted album: Andrés Cepeda - Para amarte mejor (ID: 2135)
soularr       | [INFO|soularr|L364] 2025-09-18T12:21:08+0000: Skipping denylisted album: Andrés Cepeda - Sé morir (ID: 2133)
soularr       | [INFO|soularr|L364] 2025-09-18T12:21:08+0000: Skipping denylisted album: Amy Winehouse - The Collection (ID: 2046)
soularr       | [INFO|soularr|L433] 2025-09-18T12:21:08+0000: Downloads added:
soularr       | [INFO|soularr|L440] 2025-09-18T12:21:08+0000: -------------------
soularr       | [INFO|soularr|L441] 2025-09-18T12:21:08+0000: Waiting for downloads... monitor at: http://slskd:5030/downloads
soularr       | [INFO|soularr|L477] 2025-09-18T12:21:08+0000: All tracks finished downloading!
soularr       | [INFO|soularr|L872] 2025-09-18T12:21:13+0000: Soularr finished. Exiting...
```