### PR TITLE
Wait for lidarr and slskd containers to be healthy before starting soularr container

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ services:
     ports:
       - 8686:8686
     restart: unless-stopped
+    healthcheck:
+      test: wget -O /dev/null http://localhost:8686
+      interval: 3s
+      timeout: 10s
+      retries: 10
 
   slskd:
     image: slskd/slskd
@@ -140,6 +145,11 @@ services:
       - /Containers/slskd:/app
       - /Media:/data
     restart: unless-stopped
+    healthcheck:
+      test: wget -O /dev/null http://localhost:5030
+      interval: 3s
+      timeout: 10s
+      retries: 10
 
   soularr:
     image: mrusse08/soularr:latest
@@ -153,6 +163,11 @@ services:
       - /Media/slskd_downloads:/downloads
       - /Container/soularr:/data
     restart: unless-stopped
+    depends_on:
+      lidarr:
+        condition: service_healthy
+      slskd:
+        condition: service_healthy
 ```
 
 ## Configure your config file


### PR DESCRIPTION
Wait for the lidarr and slskd containers to be healthy before starting the soularr container. The health check simply performs an HTTP request on the services.

See #153 for the motivation.