### PR TITLE
feat: add WEBUI_PORT to change the default listening port

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,12 @@ To disable it, set the environment variable:
 - WEBUI_ENABLED=false
 ```
 
+If you are running the container on a shared pod, and wish to change the port on which the web UI listens to, set the environment variable:
+
+```yml
+- WEBUI_PORT=18265
+```
+
 Thanks to [EricH9958](https://github.com/EricH9958/Soularr-Dashboard) for making the original dashboard for Soularr.
 
 ## Running Manually

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       #Script interval in seconds
       - SCRIPT_INTERVAL=300
       - WEBUI_ENABLED=true
+      - WEBUI_PORT=8265
     user: "1000:1000"
     ports:
       #Web UI port

--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,20 @@ INTERVAL=${SCRIPT_INTERVAL:-300}
 
 # Start the web UI in the background (default enabled)
 if [ "${WEBUI_ENABLED:-true}" = "true" ]; then
-    python -u /app/webui/webui.py "$@" &
+
+    # If WEBUI_PORT is set, change the default listening port
+    _WEBUI_ARGS=()
+    if [ -n "${WEBUI_PORT:-}" ]; then
+        _NUMBERRE='^[0-9]+$'
+
+        if [[ "${WEBUI_PORT}" =~ $_NUMBERRE ]]; then
+            _WEBUI_ARGS+=("--port" "${WEBUI_PORT}")
+        else
+            echo "WEBUI_PORT is not numeric, ignoring." 1>&2
+        fi
+    fi
+
+    python -u /app/webui/webui.py "${_WEBUI_ARGS[@]}" "$@" &
 fi
 
 while true; do


### PR DESCRIPTION
When running multiple containers on a shared pod, it is useful to have the ability to change the port services listen to.

Right now, there is no way to do so cleanly using the current container. Passing `--port 1234` when calling `run` causes the container to fail, as the same arguments are passed to both `webui.py` and `soularr.py`.

## Changes

- Added `WEBUI_PORT` variable to the `run.sh` file.
- Adjusted README.md to document the use of that new variable.