### PR TITLE
Standardize search_timeout to seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ skip_region_check = False
 accepted_formats = CD,Digital Media,Vinyl
 
 [Search Settings]
-search_timeout = 5000
+# Search timeout in seconds
+search_timeout = 5
 maximum_peer_queue = 50
 # Minimum upload speed (bits/sec)
 minimum_peer_upload_speed = 0

--- a/config.ini
+++ b/config.ini
@@ -22,7 +22,7 @@ skip_region_check = False
 accepted_formats = CD,Digital Media,Vinyl
 
 [Search Settings]
-search_timeout = 5000
+search_timeout = 5
 maximum_peer_queue = 50
 minimum_peer_upload_speed = 0
 minimum_filename_match_ratio = 0.8

--- a/soularr.py
+++ b/soularr.py
@@ -66,6 +66,7 @@ extensions_whitelist = []
 rename_download_folders = None
 search_sources = []
 minimum_match_ratio = None
+search_timeout = None
 minimum_search_interval = None
 page_size = None
 failed_import_denylist = None
@@ -457,7 +458,7 @@ def search_for_album(album):
     try:
         search = slskd.searches.search_text(
             searchText=query,
-            searchTimeout=config.getint("Search Settings", "search_timeout", fallback=5000),
+            searchTimeout=max(1, int(search_timeout * 1000)),
             filterResponses=True,
             maximumPeerQueueLength=config.getint("Search Settings", "maximum_peer_queue", fallback=50),
             minimumPeerUploadSpeed=config.getint("Search Settings", "minimum_peer_upload_speed", fallback=0),
@@ -473,7 +474,7 @@ def search_for_album(album):
         if slskd.searches.state(search["id"], False)["state"] != "InProgress":  # Added False here as we don't want the search results here. Just the state.
             break
         time.sleep(1)
-        if (time.time() - start_time) > config.getint("Search Settings", "search_timeout", fallback=5000):
+        if (time.time() - start_time) > search_timeout:
             logger.error("Failed to perform search via SLSKD due to timeout on search results.")
             return False
 
@@ -1259,6 +1260,7 @@ def main():
         rename_download_folders, \
         search_sources, \
         minimum_match_ratio, \
+        search_timeout, \
         minimum_search_interval, \
         page_size, \
         failed_import_denylist, \
@@ -1389,6 +1391,7 @@ def main():
             search_sources = ["missing", "cutoff_unmet"]
 
         minimum_match_ratio = config.getfloat("Search Settings", "minimum_filename_match_ratio", fallback=0.5)
+        search_timeout = config.getfloat("Search Settings", "search_timeout", fallback=5.0)
         minimum_search_interval = config.getint("Search Settings", "minimum_search_interval", fallback=5)
         page_size = config.getint("Search Settings", "number_of_albums_to_grab", fallback=10)
         failed_import_denylist = config.getboolean("Search Settings", "failed_import_denylist", fallback=True)


### PR DESCRIPTION
Fixes inconsistent search_timeout units by standardizing config to seconds and converting to milliseconds only at the SLSKD API call. Also updates docs/examples from 5000 to 5. This is a breaking config semantic change for users who previously supplied millisecond values.

Also addresses the following bug on line 476 that currently compares seconds to ms:
`if (time.time() - start_time) > config.getint("Search Settings", "search_timeout", fallback=5000):`