### PR TITLE
Make Lidarr wanted list sorting configurable and move Lidarr search options

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,23 @@ api_key = yourlidarrapikeygoeshere
 host_url = http://lidarr:8686
 # Path to slskd downloads inside the Lidarr container
 download_dir = /data/slskd_downloads
+# Search modes: all, incrementing_page, first_page
+search_type = incrementing_page
+# Sort direction options from Lidarr: ascending, descending
+sort_dir = ascending
+# Sort keys from Lidarr wanted list
+# albums.title, artists.sortName, releaseDate, albumType, albums.lastSearchTime
+sort_key = albums.title
+# Albums to process per run
+number_of_albums_to_grab = 10
+# Blacklist words in album or track titles (case-insensitive)
+title_blacklist = Word1,word2
+# Lidarr search source: "missing" or "cutoff_unmet"
+search_source = missing
 # If true, Lidarr won't auto-import from Slskd
 disable_sync = False
+# Skip re-downloading albums that previously failed to import into Lidarr
+failed_import_denylist = True
 
 [Slskd]
 # Create manually (see docs)
@@ -223,19 +238,8 @@ allowed_filetypes = flac 24/192,flac 16/44.1,flac,mp3 320,mp3
 ignored_users = User1,User2,Fred,Bob
 # Prepend artist name when searching for albums
 album_prepend_artist = False
-# Search modes: all, incrementing_page, first_page
-# "all": search for every wanted record, "first_page": repeatedly searches the first page, "incrementing_page": starts with the first page and increments on each run.
-search_type = incrementing_page
-# Albums to process per run
-number_of_albums_to_grab = 10
-# Blacklist words in album or track titles (case-insensitive)
-title_blacklist = Word1,word2
 # Blacklist words in search query (case-insensitive)
 search_blacklist = WordToStripFromSearch1,WordToStripFromSearch2
-# Lidarr search source: "missing" or "cutoff_unmet"
-search_source = missing
-# Skip re-downloading albums that previously failed to import into Lidarr
-failed_import_denylist = True
 
 [Download Settings]
 download_filtering = True

--- a/config.ini
+++ b/config.ini
@@ -2,7 +2,14 @@
 api_key = yourlidarrapikeygoeshere
 host_url = http://lidarr:8686
 download_dir = /data/slskd_downloads
+search_type = incrementing_page
+number_of_albums_to_grab = 10
+title_blacklist = BlacklistWord1,blacklistword2
+search_source = missing
+sort_dir = ascending
+sort_key = albums.title
 disable_sync = False
+failed_import_denylist = True
 
 [Slskd]
 api_key = yourslskdapikeygoeshere
@@ -30,12 +37,7 @@ minimum_search_interval = 5
 allowed_filetypes = flac 24/192,flac 16/44.1,flac,mp3 320,mp3
 ignored_users = User1,User2,Fred,Bob
 album_prepend_artist = False
-search_type = incrementing_page
-number_of_albums_to_grab = 10
-title_blacklist = BlacklistWord1,blacklistword2
 search_blacklist = WordToStripFromSearch1,WordToStripFromSearch2
-search_source = missing
-failed_import_denylist = True
 
 [Download Settings]
 download_filtering = True

--- a/soularr.py
+++ b/soularr.py
@@ -80,6 +80,8 @@ allowed_filetypes = []
 lock_file_path = None
 config_file_path = None
 current_page_file_path = None
+lidarr_sort_dir = None
+lidarr_sort_key = None
 search_blacklist = []
 
 # === Runtime State & Caches ===
@@ -392,7 +394,7 @@ def check_for_match(tracks, allowed_filetype, file_dirs, username):
 
 
 def is_blacklisted(title: str) -> bool:
-    blacklist = config.get("Search Settings", "title_blacklist", fallback="").lower().split(",")
+    blacklist = config.get("Lidarr", "title_blacklist", fallback="").lower().split(",")
     for word in blacklist:
         if word != "" and word in title.lower():
             logger.info(f"Skipping {title} due to blacklisted word: {word}")
@@ -1109,8 +1111,8 @@ def get_records(missing: bool) -> list:
     try:
         wanted = lidarr.get_wanted(
             page_size=page_size,
-            sort_dir="ascending",
-            sort_key="albums.title",
+            sort_dir=lidarr_sort_dir,
+            sort_key=lidarr_sort_key,
             missing=missing,
         )
     except ConnectionError as ex:
@@ -1127,8 +1129,8 @@ def get_records(missing: bool) -> list:
                 wanted = lidarr.get_wanted(
                     page=page,
                     page_size=page_size,
-                    sort_dir="ascending",
-                    sort_key="albums.title",
+                    sort_dir=lidarr_sort_dir,
+                    sort_key=lidarr_sort_key,
                     missing=missing,
                 )
             except ConnectionError as ex:
@@ -1142,8 +1144,8 @@ def get_records(missing: bool) -> list:
             wanted_records = lidarr.get_wanted(
                 page=page,
                 page_size=page_size,
-                sort_dir="ascending",
-                sort_key="albums.title",
+                sort_dir=lidarr_sort_dir,
+                sort_key=lidarr_sort_key,
                 missing=missing,
             )["records"]
         except ConnectionError as ex:
@@ -1158,10 +1160,10 @@ def get_records(missing: bool) -> list:
         if os.path.exists(lock_file_path) and not is_docker():
             os.remove(lock_file_path)
 
-        raise ValueError(f"[Search Settings] - {search_type = } is not valid")
+        raise ValueError(f"[Lidarr] - {search_type = } is not valid")
 
     try:
-        queued_records = lidarr.get_queue(sort_dir="ascending", sort_key="albums.title")
+        queued_records = lidarr.get_queue(sort_dir=lidarr_sort_dir, sort_key=lidarr_sort_key)
         total_queued = queued_records["totalRecords"]
         current_queue = queued_records["records"]
 
@@ -1169,7 +1171,7 @@ def get_records(missing: bool) -> list:
             page = 2
             while len(current_queue) < total_queued:
                 try:
-                    next_page = lidarr.get_queue(page=page, sort_key="albums.title", sort_dir="ascending")
+                    next_page = lidarr.get_queue(page=page, sort_key=lidarr_sort_key, sort_dir=lidarr_sort_dir)
                 except ConnectionError as ex:
                     logger.error(f"Failed to get queue details: {ex}")
                     break
@@ -1273,6 +1275,8 @@ def main():
         lock_file_path, \
         config_file_path, \
         current_page_file_path, \
+        lidarr_sort_dir, \
+        lidarr_sort_key, \
         search_blacklist, \
         lidarr, \
         slskd, \
@@ -1376,8 +1380,10 @@ def main():
         ignored_users = config.get("Search Settings", "ignored_users", fallback="").split(",")
         search_blacklist = config.get("Search Settings", "search_blacklist", fallback="").split(",")
         search_blacklist = [word.strip() for word in search_blacklist if word.strip()]
-        search_type = config.get("Search Settings", "search_type", fallback="first_page").lower().strip()
-        search_source = config.get("Search Settings", "search_source", fallback="missing").lower().strip()
+        search_type = config.get("Lidarr", "search_type", fallback="first_page").lower().strip()
+        search_source = config.get("Lidarr", "search_source", fallback="missing").lower().strip()
+        lidarr_sort_dir = config.get("Lidarr", "sort_dir", fallback="ascending").lower().strip()
+        lidarr_sort_key = config.get("Lidarr", "sort_key", fallback="albums.title").strip()
 
         download_filtering = config.getboolean("Download Settings", "download_filtering", fallback=False)
         use_extension_whitelist = config.getboolean("Download Settings", "use_extension_whitelist", fallback=False)


### PR DESCRIPTION
Makes Lidarr wanted list sorting configurable by exposing sort_dir and sort_key options.
Introduces a config breaking semantic change that improves separation of Search option contexts  by moving Lidarr search options to the [Lidarr] block.

Updated example config and README to document the new option locations and sort settings.

Added configurable Lidarr wanted-list sorting:
sort_dir with default ascending
sort_key with default albums.title

Moved these options from [Search Settings] to [Lidarr]:
search_type
number_of_albums_to_grab
title_blacklist
search_source
failed_import_denylist

[Search Settings] now refers solely to slskd queries. The config.ini layout could be improved further prior to a semantic version bump.